### PR TITLE
Fix for missing code frames in error messages.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  extends: "babel",
+  parser: "lightscript-eslint",
   parserOptions: {
     ecmaVersion: 7,
     sourceType: "module"

--- a/index.js
+++ b/index.js
@@ -410,7 +410,10 @@ exports.parseNoPatch = function (code, options) {
       ast = jsParse(code, opts);
     }
   } catch (err) {
-    if (err instanceof SyntaxError) {
+    // Any error with location information should be promoted to a code frame.
+    // Otherwise linter plugins for IDEs lose the positional information for
+    // semantic errors.
+    if (err.loc) {
       err.lineNumber = err.loc.line;
       err.column = err.loc.column + 1;
 


### PR DESCRIPTION
On upstream, if the compiler raises a semantic error, the code frame gets thrown away. This PR fixes that, keeping full positional information for any type of error that provides it.